### PR TITLE
Update docker.md

### DIFF
--- a/docs/templates/docker.md
+++ b/docs/templates/docker.md
@@ -47,5 +47,5 @@ curl https://raw.githubusercontent.com/keras-team/autokeras/master/examples/mnis
 
 Run the mnist example :
 ```
-docker run -it -v "$(pwd)":/app --shm-size 2G haifengjin/autokeras python mnist.py
+docker run -it -v "$(pwd)":/app --shm-size 2G haifengjin/autokeras python /app/mnist.py
 ```


### PR DESCRIPTION
simple path fix

typo in the docker run command. The previous command wasn't correctly pointing to mnist.py 
